### PR TITLE
fix: remove deprecated @types/jszip dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@types/jszip": "^3.4.1",
         "jszip": "^3.10.1",
         "neverthrow": "^8.0.0",
         "next": "15.3.2",
@@ -2235,15 +2234,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/jszip": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.1.tgz",
-      "integrity": "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==",
-      "deprecated": "This is a stub types definition. jszip provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "jszip": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.17.51",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@types/jszip": "^3.4.1",
     "jszip": "^3.10.1",
     "neverthrow": "^8.0.0",
     "next": "15.3.2",


### PR DESCRIPTION
## Summary
Removes the deprecated `@types/jszip` package from dependencies since `jszip` provides its own TypeScript definitions.

## Changes
- Removed `@types/jszip` from `package.json` dependencies
- Updated `package-lock.json` via `npm install`

## Benefits
- ✅ Eliminates deprecation warning
- ✅ Reduces bundle size 
- ✅ Uses official TypeScript definitions from jszip package
- ✅ All tests pass
- ✅ Build succeeds

## Testing
- [x] TypeScript type checking passes
- [x] All tests pass (214/214)
- [x] Build completes successfully
- [x] jszip functionality verified in FileExplorer component

Resolves #3

🤖 Generated with [Claude Code](https://claude.ai/code)