### PR TITLE
fix: correct backup scheduler API endpoint and request format

### DIFF
--- a/src/services/server.ts
+++ b/src/services/server.ts
@@ -198,7 +198,9 @@ export async function getBackupSettings(
     enabled: boolean | null;
     interval_hours: number | null;
     max_backups: number | null;
-  }>(`${API_BASE_URL}/api/v1/backups/scheduler/servers/${serverId}/schedule`);
+  }>(
+    `${API_BASE_URL}/api/v1/backup-scheduler/scheduler/servers/${serverId}/schedule`
+  );
 
   if (result.isErr()) {
     return err(result.error);
@@ -215,16 +217,18 @@ export async function updateBackupSettings(
   serverId: number,
   settings: BackupSettings
 ): Promise<Result<void, AuthError>> {
-  const url = new URL(
-    `${API_BASE_URL}/api/v1/backups/scheduler/servers/${serverId}/schedule`
+  return fetchEmpty(
+    `${API_BASE_URL}/api/v1/backup-scheduler/scheduler/servers/${serverId}/schedule`,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        enabled: settings.enabled,
+        interval_hours: settings.interval,
+        max_backups: settings.maxBackups,
+        only_when_running: true, // Default value as expected by backend
+      }),
+    }
   );
-  url.searchParams.set("enabled", settings.enabled.toString());
-  url.searchParams.set("interval_hours", settings.interval.toString());
-  url.searchParams.set("max_backups", settings.maxBackups.toString());
-
-  return fetchEmpty(url.toString(), {
-    method: "PUT",
-  });
 }
 
 export async function downloadBackup(


### PR DESCRIPTION
## Summary
- Fixed incorrect API endpoint path from `/api/v1/backups/scheduler/` to `/api/v1/backup-scheduler/scheduler/`
- Changed PUT request format from URL parameters to JSON body as expected by backend
- Added missing `only_when_running` parameter with default value

## Problem
The backup settings tab was returning 404 errors due to incorrect API endpoint configuration.

## Solution
- Updated endpoint paths in `getBackupSettings` and `updateBackupSettings` functions
- Converted PUT request to use JSON body instead of URL parameters
- Added required `only_when_running` field that backend expects

## Testing
- Verified with backend API documentation at `/docs#/`
- Tested schedule creation and updates work correctly
- Confirmed all CRUD operations function properly

Resolves the 404 issue reported for the backup settings functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)