### PR TITLE
Fix language change triggering unintended form submission

### DIFF
--- a/src/components/language/language-switcher.test.tsx
+++ b/src/components/language/language-switcher.test.tsx
@@ -62,4 +62,41 @@ describe("LanguageSwitcher", () => {
 
     expect(mockLocalStorage.setItem).toHaveBeenCalledWith("locale", "en");
   });
+
+  test("language buttons have type='button' to prevent form submission", () => {
+    render(
+      <TestWrapper>
+        <LanguageSwitcher />
+      </TestWrapper>
+    );
+
+    const englishButton = screen.getByText("language.english");
+    const japaneseButton = screen.getByText("language.japanese");
+
+    expect(englishButton).toHaveAttribute("type", "button");
+    expect(japaneseButton).toHaveAttribute("type", "button");
+  });
+
+  test("language change does not submit form", () => {
+    const mockSubmit = vi.fn();
+
+    render(
+      <TestWrapper>
+        <form onSubmit={mockSubmit}>
+          <LanguageSwitcher />
+          <input type="text" name="test" defaultValue="test" />
+          <button type="submit">Submit</button>
+        </form>
+      </TestWrapper>
+    );
+
+    const japaneseButton = screen.getByText("language.japanese");
+    fireEvent.click(japaneseButton);
+
+    // Form should not be submitted when language button is clicked
+    expect(mockSubmit).not.toHaveBeenCalled();
+
+    // But language should be changed
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith("locale", "ja");
+  });
 });

--- a/src/components/language/language-switcher.tsx
+++ b/src/components/language/language-switcher.tsx
@@ -14,7 +14,11 @@ export function LanguageSwitcher({
   const { locale, setLocale } = useLanguage();
   const { t } = useTranslation();
 
-  const handleLanguageChange = (newLocale: Locale) => {
+  const handleLanguageChange = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    newLocale: Locale
+  ) => {
+    event.preventDefault();
     setLocale(newLocale);
   };
 
@@ -23,13 +27,15 @@ export function LanguageSwitcher({
       <label className={styles.label}>{t("language.switchLanguage")}</label>
       <div className={styles.buttons}>
         <button
-          onClick={() => handleLanguageChange("en")}
+          type="button"
+          onClick={(e) => handleLanguageChange(e, "en")}
           className={`${styles.button} ${locale === "en" ? styles.active : ""}`}
         >
           {t("language.english")}
         </button>
         <button
-          onClick={() => handleLanguageChange("ja")}
+          type="button"
+          onClick={(e) => handleLanguageChange(e, "ja")}
           className={`${styles.button} ${locale === "ja" ? styles.active : ""}`}
         >
           {t("language.japanese")}


### PR DESCRIPTION
## Summary

This PR fixes the issue where changing the language in login/registration forms would unintentionally submit the form when username and password fields were filled.

## Problem

When users had entered their credentials in the login or registration form and clicked the language change button (EN/JA), the form would be submitted automatically. This happened because the language switcher buttons didn't have an explicit `type` attribute, causing them to default to `type="submit"` when placed inside a form.

## Solution

1. Added `type="button"` to both language switcher buttons
2. Added `event.preventDefault()` to the language change handler for extra safety
3. Updated event handler signature to accept the click event

## Testing

- ✅ Added new tests to verify buttons have `type="button"` attribute
- ✅ Added test to ensure language change doesn't submit forms
- ✅ All existing tests continue to pass (716 tests)
- ✅ TypeScript type checking passed
- ✅ ESLint checks passed

## How to Test

1. Navigate to the login page
2. Enter username and password
3. Click the language change button (EN/JA)
4. Verify that:
   - The language changes
   - The form is NOT submitted
   - Your entered data remains in the fields

Resolves #97

🤖 Generated with [Claude Code](https://claude.ai/code)