### PR TITLE
Add password visibility toggle feature for authentication forms (#100)

### DIFF
--- a/src/components/auth/auth-form.module.css
+++ b/src/components/auth/auth-form.module.css
@@ -68,6 +68,71 @@
   cursor: not-allowed;
 }
 
+.passwordWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.passwordInput {
+  width: 100%;
+  min-width: 0;
+  padding: 0.75rem;
+  padding-right: 3rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 1rem;
+  box-sizing: border-box;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.passwordInput:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.passwordInput:disabled {
+  background-color: #f9fafb;
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
+.toggleButton {
+  position: absolute;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  color: #6b7280;
+  font-size: 1.125rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 2px;
+  transition: color 0.2s;
+}
+
+.toggleButton:hover:not(:disabled) {
+  color: #374151;
+}
+
+.toggleButton:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.toggleButton:disabled {
+  color: #d1d5db;
+  cursor: not-allowed;
+}
+
 .submitButton {
   width: 100%;
   height: 3rem;

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -22,6 +22,7 @@ export function LoginForm({ onSuccess, onSwitchToRegister }: LoginFormProps) {
   });
   const [error, setError] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [showPassword, setShowPassword] = useState<boolean>(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -105,6 +106,10 @@ export function LoginForm({ onSuccess, onSwitchToRegister }: LoginFormProps) {
     }
   };
 
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
       <div className={styles.header}>
@@ -142,19 +147,35 @@ export function LoginForm({ onSuccess, onSwitchToRegister }: LoginFormProps) {
         <label htmlFor="password" className={styles.label}>
           {t("auth.password")}
         </label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          value={formData.password}
-          onChange={handleInputChange}
-          className={styles.input}
-          disabled={isLoading}
-          required
-          minLength={6}
-          maxLength={128}
-          autoComplete="current-password"
-        />
+        <div className={styles.passwordWrapper}>
+          <input
+            id="password"
+            name="password"
+            type={showPassword ? "text" : "password"}
+            value={formData.password}
+            onChange={handleInputChange}
+            className={styles.passwordInput}
+            disabled={isLoading}
+            required
+            minLength={6}
+            maxLength={128}
+            autoComplete="current-password"
+          />
+          <button
+            type="button"
+            className={styles.toggleButton}
+            onClick={togglePasswordVisibility}
+            disabled={isLoading}
+            aria-label={
+              showPassword ? t("auth.hidePassword") : t("auth.showPassword")
+            }
+            title={
+              showPassword ? t("auth.hidePassword") : t("auth.showPassword")
+            }
+          >
+            {showPassword ? "🙈" : "👁️"}
+          </button>
+        </div>
       </div>
 
       <button

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -27,6 +27,9 @@ export function RegisterForm({
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string>("");
   const [success, setSuccess] = useState<string>("");
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] =
+    useState<boolean>(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -160,6 +163,14 @@ export function RegisterForm({
     }
   };
 
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  const toggleConfirmPasswordVisibility = () => {
+    setShowConfirmPassword(!showConfirmPassword);
+  };
+
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
       <div className={styles.header}>
@@ -222,39 +233,75 @@ export function RegisterForm({
         <label htmlFor="password" className={styles.label}>
           {t("auth.password")}
         </label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          value={formData.password}
-          onChange={handleInputChange}
-          className={styles.input}
-          disabled={isLoading}
-          required
-          minLength={8}
-          maxLength={128}
-          autoComplete="new-password"
-          title={t("auth.errors.passwordMinLength")}
-        />
+        <div className={styles.passwordWrapper}>
+          <input
+            id="password"
+            name="password"
+            type={showPassword ? "text" : "password"}
+            value={formData.password}
+            onChange={handleInputChange}
+            className={styles.passwordInput}
+            disabled={isLoading}
+            required
+            minLength={8}
+            maxLength={128}
+            autoComplete="new-password"
+            title={t("auth.errors.passwordMinLength")}
+          />
+          <button
+            type="button"
+            className={styles.toggleButton}
+            onClick={togglePasswordVisibility}
+            disabled={isLoading}
+            aria-label={
+              showPassword ? t("auth.hidePassword") : t("auth.showPassword")
+            }
+            title={
+              showPassword ? t("auth.hidePassword") : t("auth.showPassword")
+            }
+          >
+            {showPassword ? "🙈" : "👁️"}
+          </button>
+        </div>
       </div>
 
       <div className={styles.field}>
         <label htmlFor="confirmPassword" className={styles.label}>
           {t("auth.confirmPassword")}
         </label>
-        <input
-          id="confirmPassword"
-          name="confirmPassword"
-          type="password"
-          value={confirmPassword}
-          onChange={handleInputChange}
-          className={styles.input}
-          disabled={isLoading}
-          required
-          minLength={8}
-          maxLength={128}
-          autoComplete="new-password"
-        />
+        <div className={styles.passwordWrapper}>
+          <input
+            id="confirmPassword"
+            name="confirmPassword"
+            type={showConfirmPassword ? "text" : "password"}
+            value={confirmPassword}
+            onChange={handleInputChange}
+            className={styles.passwordInput}
+            disabled={isLoading}
+            required
+            minLength={8}
+            maxLength={128}
+            autoComplete="new-password"
+          />
+          <button
+            type="button"
+            className={styles.toggleButton}
+            onClick={toggleConfirmPasswordVisibility}
+            disabled={isLoading}
+            aria-label={
+              showConfirmPassword
+                ? t("auth.hidePassword")
+                : t("auth.showPassword")
+            }
+            title={
+              showConfirmPassword
+                ? t("auth.hidePassword")
+                : t("auth.showPassword")
+            }
+          >
+            {showConfirmPassword ? "🙈" : "👁️"}
+          </button>
+        </div>
       </div>
 
       <button

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -54,6 +54,8 @@
     "registerHere": "Register here",
     "loginHere": "Login here",
     "usernameTooltip": "Username must contain only letters, numbers, underscores, and hyphens",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
     "errors": {
       "usernameRequired": "Username is required and must contain only valid characters",
       "passwordRequired": "Password is required",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -54,6 +54,8 @@
     "registerHere": "こちらから登録",
     "loginHere": "こちらからログイン",
     "usernameTooltip": "ユーザー名には文字、数字、アンダースコア、ハイフンのみ使用できます",
+    "showPassword": "パスワードを表示",
+    "hidePassword": "パスワードを非表示",
     "errors": {
       "usernameRequired": "ユーザー名は必須です。有効な文字のみを含む必要があります",
       "passwordRequired": "パスワードは必須です",


### PR DESCRIPTION
## Summary
- Implement password show/hide toggle buttons for login and registration forms
- Add eye/eye-slash emoji icons to indicate current visibility state
- Include comprehensive internationalization support for Japanese and English
- Implement accessibility features with proper ARIA labels and keyboard navigation

## Changes Made
- **Login Form**: Added password visibility toggle with eye/eye-slash emoji icons
- **Register Form**: Added toggles for both password and confirm password fields  
- **CSS Styling**: Added responsive styling for positioned toggle buttons with hover/focus states
- **Internationalization**: Added translation keys for "Show password" and "Hide password" in both English and Japanese
- **Accessibility**: Implemented ARIA labels, keyboard navigation, and screen reader support

## Implementation Details
- Toggle buttons positioned absolutely within password input wrappers
- Password input padding adjusted to accommodate toggle button space
- State management for individual password field visibility
- Consistent styling with existing form components
- Proper form validation and security maintained

## Testing
- All existing tests continue to pass (716/716)
- TypeScript type checking passes
- ESLint and Prettier formatting applied
- Build process successful

## Accessibility Features
- ARIA labels dynamically updated based on visibility state
- Keyboard navigation support with proper focus indicators
- Screen reader friendly with descriptive button labels
- Consistent with WCAG accessibility guidelines

Resolves #100

🤖 Generated with [Claude Code](https://claude.ai/code)