### PR TITLE
fix: Add missing Japanese translations for server creation memory options

### DIFF
--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -330,6 +330,18 @@
       "descriptionPlaceholder": "サーバーの説明を入力...",
       "creating": "作成中...",
       "createButton": "サーバー作成",
+      "serverTypes": {
+        "vanilla": "Vanilla",
+        "paper": "Paper",
+        "forge": "Forge"
+      },
+      "memoryOptions": {
+        "1024": "1 GB",
+        "2048": "2 GB",
+        "4096": "4 GB",
+        "8192": "8 GB",
+        "16384": "16 GB"
+      },
       "loadingVersions": "バージョン読み込み中...",
       "noVersionsAvailable": "利用可能なバージョンがありません",
       "errors": {


### PR DESCRIPTION
## Summary

- Add missing `serverTypes` translations (vanilla, paper, forge) to `servers.create` section in Japanese locale
- Add missing `memoryOptions` translations (1GB, 2GB, 4GB, 8GB, 16GB) to `servers.create` section in Japanese locale
- Resolves issue with untranslated memory options in Japanese locale causing display issues

## Changes Made

### Translation Files Updated
- `src/i18n/messages/ja.json`: Added missing translation keys under `servers.create` section

### Added Translation Keys
```json
"serverTypes": {
  "vanilla": "Vanilla",
  "paper": "Paper",
  "forge": "Forge"
},
"memoryOptions": {
  "1024": "1 GB",
  "2048": "2 GB",
  "4096": "4 GB",
  "8192": "8 GB",
  "16384": "16 GB"
}
```

## Testing

- ✅ All existing tests pass (78/78 tests)
- ✅ ESLint: No warnings or errors
- ✅ TypeScript: Type checking passes
- ✅ Prettier: Code formatting verified
- ✅ Verified existing implementation correctly uses these translation keys

## Impact

- Japanese users will now see properly translated memory options during server creation
- Server type options are now properly localized for Japanese users
- Maintains consistency between English and Japanese translation files

## Test Plan

- [x] Run full test suite and verify all tests pass
- [x] Check that existing server creation UI components use these translation keys
- [x] Verify no linting or type checking errors
- [x] Confirm all CI checks pass

Resolves #145

🤖 Generated with [Claude Code](https://claude.ai/code)